### PR TITLE
Add credit card fraud notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Intro_ML_Project1
-Introductory Machine learning Projects. In this project data was cleaned and divided up to be trained with this (model) to predict what type of dish is based off the recipes ingredients.  
+This repository contains small machine learning projects.
+
+## Credit Card Fraud Notebook
+A Jupyter notebook is included in `notebooks/credit_card_fraud_models.ipynb` which demonstrates training several models on the [Kaggle credit card fraud dataset](https://www.kaggle.com/mlg-ulb/creditcardfraud). The notebook loads the CSV file, splits the data, and compares logistic regression, decision tree, and random forest classifiers.

--- a/notebooks/credit_card_fraud_models.ipynb
+++ b/notebooks/credit_card_fraud_models.ipynb
@@ -1,0 +1,124 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Credit Card Fraud Detection\n",
+        "This notebook demonstrates training multiple models on the Kaggle credit card fraud detection dataset. Each transaction has 30 PCA components plus `Amount` and `Time` features."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import pandas as pd\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.preprocessing import StandardScaler\n",
+        "from sklearn.metrics import classification_report\n",
+        "from sklearn.linear_model import LogisticRegression\n",
+        "from sklearn.tree import DecisionTreeClassifier\n",
+        "from sklearn.ensemble import RandomForestClassifier\n",
+        "from sklearn.pipeline import make_pipeline"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load data\n",
+        "Assumes the CSV file is available locally as `creditcard.csv`. You can download it from Kaggle: https://www.kaggle.com/mlg-ulb/creditcardfraud"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "df = pd.read_csv('creditcard.csv')\n",
+        "df.head()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Prepare features and labels"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "X = df.drop('Class', axis=1)\n",
+        "y = df['Class']\n",
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Model 1: Logistic Regression"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "log_reg = make_pipeline(StandardScaler(), LogisticRegression(max_iter=1000))\n",
+        "log_reg.fit(X_train, y_train)\n",
+        "y_pred = log_reg.predict(X_test)\n",
+        "print(classification_report(y_test, y_pred))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Model 2: Decision Tree"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "tree = DecisionTreeClassifier(max_depth=4)\n",
+        "tree.fit(X_train, y_train)\n",
+        "y_pred = tree.predict(X_test)\n",
+        "print(classification_report(y_test, y_pred))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Model 3: Random Forest"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "forest = RandomForestClassifier(n_estimators=100, random_state=42, n_jobs=-1)\n",
+        "forest.fit(X_train, y_train)\n",
+        "y_pred = forest.predict(X_test)\n",
+        "print(classification_report(y_test, y_pred))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new notebook for credit card fraud detection using logistic regression, decision tree, and random forest
- update README with instructions for the new notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407c058974832d906ef4002726dc01